### PR TITLE
Reduce parallel optimizations

### DIFF
--- a/lib/default-config.coffee
+++ b/lib/default-config.coffee
@@ -99,6 +99,8 @@ defaultConfig =
 
   # Optimize files after a build.
   # Paths are rooted at the build directory.
+  limit: 3
+
   optimize:
     '/main.js': (file, callback) ->
       UglifyJS = require 'uglify-js'

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "haw": "./bin/haw"
   },
   "dependencies": {
+    "async": "~0.9.0",
     "browserify": "~3.32.0",
     "browserify-eco": "~0.2.4",
     "chalk": "~0.4.0",


### PR DESCRIPTION
Was running into a problem on projects with a lot of images where haw went to optimize all of them at once and slowed my Air to a crawl.

This PR limits the number of parallel optimizations to 3, which is the highest number that didn't max my CPU.

This does increase build times by roughly 15%. Though I can't imagine it makes much of a difference on a project with just a couple images.
